### PR TITLE
added --browser CLI key

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -97,6 +97,9 @@
     
     --pool {mongo|memcache}://{host}:{port}/{db_name|namespace}/{cltn_name}
   
+    By default console is opened in system default browser. You can pass arbitrary binary with
+    '--browser' CLI key.
+
 == LICENSE:
 
 Copyright 2009-2010 LiquidRail LLC

--- a/bin/mongo3
+++ b/bin/mongo3
@@ -14,7 +14,12 @@ Main {
     default 'production'
     description 'Specifies the env to run mongo3 in'
   }
-  
+  option( 'browser', 'b' ) {
+    argument :optional
+    default 'system'
+    description 'Specifies browser binary to run upon webserver start'
+  }
+
   @@options = {}
   
   # Enter main loop  
@@ -53,13 +58,18 @@ Main {
   
   # open console...
   def open(path)
-    case RUBY_PLATFORM
-      when /darwin/
-        system 'open', path
-      when /mswin(?!ce)|mingw|cygwin|bccwin/
-        system 'start', path
-      else
-        system 'firefox', path
+    browser = params[:browser].value
+    if browser == 'system' then
+      case RUBY_PLATFORM
+        when /darwin/
+          system 'open', path
+        when /mswin(?!ce)|mingw|cygwin|bccwin/
+          system 'start', path
+        else
+          system 'firefox', path
+      end
+    else
+      system browser, path
     end
   end
   


### PR DESCRIPTION
allows to run mongo3 console in arbitrary browser with `--browser` CLI key
