### PR TITLE
Tweak/fix linux browser

### DIFF
--- a/bin/mongo3
+++ b/bin/mongo3
@@ -58,8 +58,11 @@ Main {
         system 'open', path
       when /mswin(?!ce)|mingw|cygwin|bccwin/
         system 'start', path
-      else
+      when /linux/
+        #TODO: figure out DE-agnostic handler
         system 'xdg-open', path
+      else
+        system 'firefox', path
     end
   end
   

--- a/bin/mongo3
+++ b/bin/mongo3
@@ -59,7 +59,7 @@ Main {
       when /mswin(?!ce)|mingw|cygwin|bccwin/
         system 'start', path
       else
-        system 'firefox', path
+        system 'xdg-open', path
     end
   end
   


### PR DESCRIPTION
this makes console open with `xdg-open` on linux, not `firefox` (for chrom(e|ium)|opera|epiphany users)
