### PR TITLE
Use public_folder instead of public, as the warning says

### DIFF
--- a/lib/helpers/main_helper.rb
+++ b/lib/helpers/main_helper.rb
@@ -18,11 +18,11 @@ module MainHelper
     end
           
     def v_styles(stylesheet)
-      "/stylesheets/#{stylesheet}.css?" + File.mtime(File.join(Sinatra::Application.public, "stylesheets", "#{stylesheet}.css")).to_i.to_s
+      "/stylesheets/#{stylesheet}.css?" + File.mtime(File.join(Sinatra::Application.public_folder, "stylesheets", "#{stylesheet}.css")).to_i.to_s
     end
     
     def v_js(js)
-      "/javascripts/#{js}.js?" + File.mtime(File.join(Sinatra::Application.public, "javascripts", "#{js}.js")).to_i.to_s
+      "/javascripts/#{js}.js?" + File.mtime(File.join(Sinatra::Application.public_folder, "javascripts", "#{js}.js")).to_i.to_s
     end
       
     def zone_locator


### PR DESCRIPTION
This fixes the crash caused by using Sinatra's old #public method, which was renamed to #public_folder.
