### PR TITLE
mongo3 fails on the public method

### DIFF
--- a/lib/helpers/main_helper.rb
+++ b/lib/helpers/main_helper.rb
@@ -18,11 +18,11 @@ module MainHelper
     end
           
     def v_styles(stylesheet)
-      "/stylesheets/#{stylesheet}.css?" + File.mtime(File.join(Sinatra::Application.public, "stylesheets", "#{stylesheet}.css")).to_i.to_s
+      "/stylesheets/#{stylesheet}.css?" + File.mtime(File.join(Sinatra::Application.root, "..", "lib", "public", "stylesheets", "#{stylesheet}.css")).to_i.to_s
     end
     
     def v_js(js)
-      "/javascripts/#{js}.js?" + File.mtime(File.join(Sinatra::Application.public, "javascripts", "#{js}.js")).to_i.to_s
+      "/javascripts/#{js}.js?" + File.mtime(File.join(Sinatra::Application.root, "..", "lib", "public", "javascripts", "#{js}.js")).to_i.to_s
     end
       
     def zone_locator


### PR DESCRIPTION
changed to root and to a subpath that works for sinatra 1.3.0+
